### PR TITLE
Move paper and fix formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,6 @@ The final SNARK used in Nova (only using MSMs)
 - [Scalable Zero Knowledge via Cycles of Elliptic Curves](http://eprint.iacr.org/2014/595)
     - This paper introduces the notion of pairing-friendly cycles of curves, and shows how to use these to construct the first concretely efficient IVC/PCD scheme.
 
-- [Revisiting the Nova Proof System on a Cycle of Curves](https://eprint.iacr.org/2023/969)
-  - This paper analyzes the security of the Nova proving system when implemented on a cycle of curves.
-  The paper exploits a soundness bug in the original implementation (since patched) and produces a
-  convincing proof of $$2^75$$ rounds of the Minroot VDF in 1.46 seconds. A new optimized and secure
-  system is introduced together with a formal security proof.
-
 #### Halo
 
 The prototype of the delayed proving approach which Nova puts on steroids.
@@ -95,6 +89,12 @@ Classic works on the Nova proof system, including seminal papers and accompanyin
     - [Presentation](https://www.youtube.com/watch?v=BiKMCNKwaec)
 - [Sangria: a Folding Scheme for PLONK](https://github.com/geometryresearch/technical_notes/blob/main/sangria_folding_plonk.pdf)
     - [Presentation](https://www.youtube.com/watch?v=D7rQbHpxl7Q)
+- [Revisiting the Nova Proof System on a Cycle of Curves](https://eprint.iacr.org/2023/969)
+    - This paper analyzes the security of the Nova proving system when implemented on a cycle of curves.
+    The paper exploits a soundness bug in the original implementation (since patched) and produces a
+    convincing proof of $2^{75}$ rounds of the Minroot VDF in 1.46 seconds. A new optimized and secure
+    system is introduced together with a formal security proof.
+
 
 ### Nova Extensions (without high-degree gates)
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ Classic works on the Nova proof system, including seminal papers and accompanyin
     convincing proof of $2^{75}$ rounds of the Minroot VDF in 1.46 seconds. A new optimized and secure
     system is introduced together with a formal security proof.
 
-
 ### Nova Extensions (without high-degree gates)
 
 Extensions to the Nova proof system that explore PCS in terms of linear codes, folding, and other concepts.


### PR DESCRIPTION
This PR cleans up the mess I made with the last set of changes. 

It moves the new paper just added to a more appropriate section, and also fixes the LaTeX formatting which was displaying incorrectly:

![Screenshot from 2023-06-22 18-50-19](https://github.com/lurk-lab/awesome-folding/assets/96667244/2d5dcf5c-3424-4bb4-9a24-097224fa9877)